### PR TITLE
chore: release pipeline and reproducible build config

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -24,6 +24,13 @@ repositories {
 	mavenCentral()
 }
 
+// Reproducible build to preserve checksum value with rebuilds
+tasks.withType(AbstractArchiveTask) {
+	preserveFileTimestamps = false
+	reproducibleFileOrder = true
+}
+
+
 test {
 	useJUnitPlatform()
 	finalizedBy jacocoTestReport

--- a/misc/updatebrew.sh
+++ b/misc/updatebrew.sh
@@ -8,6 +8,8 @@ mulefd_version=`ls build/distributions/mulefd-*.*.zip | sed -e 's/.*mulefd-\(.*\
 echo "Updating mulefd brew with version $mulefd_version from `pwd`"
 DIST=`ls build/distributions/mulefd-${mulefd_version}.zip | cut -f1 -d ' '`
 sha256=`cat $DIST.sha256`
+echo "DIST: ${DIST}"
+echo "SHA256: ${sha256}"
 
 rm -rf homebrew-tap
 git clone https://github.com/manikmagar/homebrew-tap.git
@@ -16,7 +18,7 @@ cp build/brew/formula/mulefd.rb homebrew-tap/Formula/mulefd.rb
 
 cd homebrew-tap
 
-git config user.name "Manik Magar"
+git config user.name "manikmagar"
 git config user.email "${GIT_USER_EMAIL}"
 
 

--- a/misc/updatecontainer.sh
+++ b/misc/updatecontainer.sh
@@ -8,22 +8,24 @@ mulefd_version=`ls build/distributions/mulefd-*.*.zip | sed -e 's/.*mulefd-\(.*\
 echo "Updating mulefd docker with version $mulefd_version from `pwd`"
 DIST=`ls build/distributions/mulefd-${mulefd_version}.zip | cut -f1 -d ' '`
 sha256=`cat $DIST.sha256`
+echo "DIST: ${DIST}"
+echo "SHA256: ${sha256}"
 
 rm -rf mulefd-docker
 git clone https://github.com/manikmagar/mulefd-docker.git
 
 cp build/container/Dockerfile mulefd-docker/Dockerfile
-cp build/container/README.md mulefd-docker/README.md
+cp build/container/README.adoc mulefd-docker/README.adoc
 
 cd mulefd-docker
 
-git config user.name "Manik Magar"
+git config user.name "manikmagar"
 git config user.email "${GIT_USER_EMAIL}"
 
 
 git add Dockerfile README.adoc
 git commit -m "mulefd v${mulefd_version}"
-git tag -a "v${mulefd_version}" -m "mulefd v${mulefd_version}"
+git tag -a "${mulefd_version}" -m "mulefd v${mulefd_version}"
 
 remote_repo="https://${MULEFD_USER}:${MULEFD_TOKEN}@github.com/manikmagar/mulefd-docker.git"
 echo $remote_repo

--- a/misc/updatescoop.sh
+++ b/misc/updatescoop.sh
@@ -8,6 +8,8 @@ mulefd_version=`ls build/distributions/mulefd-*.*.zip | sed -e 's/.*mulefd-\(.*\
 echo "Updating mulefd scoop with version $mulefd_version from `pwd`"
 DIST=`ls build/distributions/mulefd-${mulefd_version}.zip | cut -f1 -d ' '`
 sha256=`cat $DIST.sha256`
+echo "DIST: ${DIST}"
+echo "SHA256: ${sha256}"
 
 rm -rf scoop-bucket
 git clone https://github.com/manikmagar/scoop-bucket.git
@@ -16,7 +18,7 @@ cp build/scoop/mulefd.json scoop-bucket/mulefd.json
 
 cd scoop-bucket
 
-git config user.name "Manik Magar"
+git config user.name "manikmagar"
 git config user.email "${GIT_USER_EMAIL}"
 
 


### PR DESCRIPTION
Previous brew update had different sha56 than that of released .sha256 in github releases. This was due non-reproducible builds which results in different SHA256 each time. This commit adds configuration as suggested [here](https://docs.gradle.org/current/userguide/working_with_files.html#sec:reproducible_archives). SHA256 is same across multiple builds of same code base.