### PR TITLE
fix: generation for xml path without parent

### DIFF
--- a/src/main/java/com/javastreets/mulefd/app/Application.java
+++ b/src/main/java/com/javastreets/mulefd/app/Application.java
@@ -70,7 +70,7 @@ public class Application implements Callable<Boolean> {
       if (Files.isDirectory(sourcePath))
         resolvedTarget = sourcePath;
       if (Files.isRegularFile(sourcePath))
-        resolvedTarget = sourcePath.toFile().getParentFile().toPath();
+        resolvedTarget = sourcePath.toAbsolutePath().getParent();
     }
     cm.setTargetPath(resolvedTarget);
     cm.setDiagramType(diagramType);

--- a/src/test/java/com/javastreets/mulefd/app/ApplicationTest.java
+++ b/src/test/java/com/javastreets/mulefd/app/ApplicationTest.java
@@ -90,6 +90,28 @@ class ApplicationTest {
   }
 
   @Test
+  @DisplayName("When parsing source file without parent folder, sets parent as target")
+  void commandLineWithBareSourceFile() throws Exception {
+    tempDir.createNewFile();
+    Path sourceFile = Paths.get("db-config.xml");
+    sourceFile.toFile().delete();
+    Files.copy(Paths.get("src/test/resources/renderer/component-configs/db-config.xml"),
+        sourceFile);
+    String[] args = new String[] {sourceFile.toString()};
+    Application application = new Application();
+    new CommandLine(application).parseArgs(args);
+    CommandModel model = application.getCommandModel();
+
+    CommandModel expectedModel = new CommandModel();
+    expectedModel.setSourcePath(sourceFile);
+    expectedModel.setTargetPath(sourceFile.toAbsolutePath().getParent());
+    expectedModel.setDiagramType(DiagramType.GRAPH);
+    expectedModel.setOutputFilename("mule-diagram.png");
+    expectedModel.setGenerateSingles(false);
+    assertThat(model).isEqualToComparingFieldByField(expectedModel);
+  }
+
+  @Test
   @DisplayName("When parsing source file, sets parent as target")
   void commandLineWithSourceFile() throws Exception {
     tempDir.createNewFile();


### PR DESCRIPTION
fixes #123 

example - `mulefd test-api.xml` will not fail now.

[patch]