### PR TITLE
Use default available Graphviz engines

### DIFF
--- a/CONTRIBUTING.adoc
+++ b/CONTRIBUTING.adoc
@@ -26,7 +26,7 @@ Intent is that on merge we squash to get as clean as changelog as possible.
 == Source formatting
 
 The build uses the https://github.com/diffplug/spotless[spotless] plugin to ensure Java and other files are formatted uniformly.
-If your build fails due to formatting errors then run `gradle spotlessApply` and it will reformat to be compatible.
+If your build fails due to formatting errors then run `./gradlew spotlessApply` and it will reformat to be compatible.
 
 == Versioning
 
@@ -47,14 +47,14 @@ Run a build check to see if things are clean:
 
 [source,shell]
 ----
-$ gradle spotlessApply build clean
+$ ./gradlew spotlessApply build clean
 ----
 
 if nothing changed (use `git status`) then run:
 
 [source,shell]
 ----
-$ gradle printVersion
+$ ./gradlew printVersion
 ----
 
 to see if the right version are printed.
@@ -64,15 +64,15 @@ If 4 digits then make sure last commit as a `[minor]` or `[patch]` as part of it
 
 Once ready run:
 
-`$ gradle changelog`
+`$ ./gradlew changelog`
 
 This will generate `CHANGELOG.md` using commitizen conventions.
 
-Edit the channgelog with some header on what changed in an overview form.
+Edit the changelog with some header on what changed in an overview form.
 
 Then run:
 
-`$ gradle tag`
+`$ ./gradlew tag`
 
 This will create an annotated tag using the `CHANGELOG.md` message.
 

--- a/README.adoc
+++ b/README.adoc
@@ -306,6 +306,22 @@ If `mulefd-components.csv` named CSV file exists in `sourcePath`, then all modul
 
 See example file at link:src/test/resources/mulefd-components.csv[].
 
+== Troubleshooting
+
+=== Getting None of the provided engines could be initialized
+This tool uses Graphviz-Java library to generate diagrams. Graphviz-Java https://github.com/nidi3/graphviz-java#how-it-works[describes] how the engines are leveraged. To execute the graphviz layout engine, one of these options is used:
+
+. If the machine has graphviz installed and a `dot` command is available, spawn a new process running dot.
+. Use this https://github.com/mdaines/viz.js[javascript version] of graphviz and execute it on the V8 javascript engine. This is done with the bundled https://github.com/eclipsesource/J2V8[J2V8] library.
+. Alternatively, the javascript can be executed on Java's own Nashorn or GraalVM engine (preferring Graal if both are available).
+
+This tool bundles the J2V8 library but it https://github.com/manikmagar/mulefd/issues/244[does not support] Apple M1. The Java's Nashorn engine was deprecated starting JDK 9 and removed in JDK 15.
+
+So, if your diagram generation is failing with that error then check one of the following -
+
+1. Which JDK is used? Using JDK's prior to 15 will at-least make the Nashorn engine available. It may be slower to run when compared to others.
+2. If JDK 15+ is being used on Apple M1, make sure the `dot` is installed. It is a part of Graphviz, so check https://graphviz.org/download/#mac[here] for installing graphviz with `brew install graphviz`.
+
 == Copyright & License
 
 Licensed under the MIT License, see the link:LICENSE[LICENSE] file for details.

--- a/src/main/java/com/javastreets/mulefd/drawings/GraphDiagram.java
+++ b/src/main/java/com/javastreets/mulefd/drawings/GraphDiagram.java
@@ -27,7 +27,6 @@ import com.javastreets.mulefd.util.DateUtil;
 import guru.nidi.graphviz.attribute.*;
 import guru.nidi.graphviz.engine.Format;
 import guru.nidi.graphviz.engine.Graphviz;
-import guru.nidi.graphviz.engine.GraphvizV8Engine;
 import guru.nidi.graphviz.model.Link;
 import guru.nidi.graphviz.model.MutableGraph;
 import guru.nidi.graphviz.model.MutableNode;
@@ -140,7 +139,11 @@ public class GraphDiagram implements Diagram {
   boolean writGraphToFile(File outputFilename, MutableGraph graph) {
     try {
       log.debug("Writing graph at path {}", outputFilename);
-      Graphviz.useEngine(new GraphvizV8Engine());
+      // See https://github.com/nidi3/graphviz-java#how-it-works for which engines are used.
+      // Known Limitations:
+      // 1. J2V8 engines isn't available for Apple M1
+      // 2. Java Nashorn engine is deprecated by JDK and removed in JDK 15.
+      Graphviz.useDefaultEngines();
       boolean generated =
           Graphviz.fromGraph(graph).render(Format.PNG).toFile(outputFilename).exists();
       Graphviz.releaseEngine();

--- a/src/test/java/com/javastreets/mulefd/drawings/GraphDiagramTest.java
+++ b/src/test/java/com/javastreets/mulefd/drawings/GraphDiagramTest.java
@@ -36,7 +36,6 @@ import guru.nidi.graphviz.attribute.Label;
 import guru.nidi.graphviz.attribute.Rank;
 import guru.nidi.graphviz.engine.Format;
 import guru.nidi.graphviz.engine.Graphviz;
-import guru.nidi.graphviz.engine.GraphvizV8Engine;
 import guru.nidi.graphviz.model.MutableGraph;
 import io.github.netmikey.logunit.api.LogCapturer;
 
@@ -126,7 +125,7 @@ class GraphDiagramTest {
     ArgumentCaptor<MutableGraph> graphArgumentCaptor = ArgumentCaptor.forClass(MutableGraph.class);
     verify(graphDiagram).writGraphToFile(any(File.class), graphArgumentCaptor.capture());
     MutableGraph generatedGraph = graphArgumentCaptor.getValue();
-    Graphviz.useEngine(new GraphvizV8Engine());
+    Graphviz.useDefaultEngines();
     String jsonGraph = Graphviz.fromGraph(generatedGraph).render(Format.JSON).toString();
     String ref = new String(Files.readAllBytes(Paths
         .get("src/test/java/com/javastreets/mulefd/drawings/drawToValidateGraph_Expected.json")));
@@ -161,7 +160,7 @@ class GraphDiagramTest {
     ArgumentCaptor<MutableGraph> graphArgumentCaptor = ArgumentCaptor.forClass(MutableGraph.class);
     verify(graphDiagram).writGraphToFile(any(File.class), graphArgumentCaptor.capture());
     MutableGraph generatedGraph = graphArgumentCaptor.getValue();
-    Graphviz.useEngine(new GraphvizV8Engine());
+    Graphviz.useDefaultEngines();
     String jsonGraph = Graphviz.fromGraph(generatedGraph).render(Format.JSON).toString();
     String ref = new String(Files.readAllBytes(Paths.get(
         "src/test/java/com/javastreets/mulefd/drawings/drawToValidateGraph_APIKIT_Expected.json")));
@@ -190,7 +189,7 @@ class GraphDiagramTest {
     ArgumentCaptor<MutableGraph> graphArgumentCaptor = ArgumentCaptor.forClass(MutableGraph.class);
     verify(graphDiagram).writGraphToFile(any(File.class), graphArgumentCaptor.capture());
     MutableGraph generatedGraph = graphArgumentCaptor.getValue();
-    Graphviz.useEngine(new GraphvizV8Engine());
+    Graphviz.useDefaultEngines();
     String jsonGraph = Graphviz.fromGraph(generatedGraph).render(Format.JSON).toString();
     String ref = new String(
         Files.readAllBytes(Paths.get("src/test/resources/single-flow-generation-example.json")));
@@ -214,7 +213,7 @@ class GraphDiagramTest {
     ArgumentCaptor<MutableGraph> graphArgumentCaptor = ArgumentCaptor.forClass(MutableGraph.class);
     verify(graphDiagram).writGraphToFile(any(File.class), graphArgumentCaptor.capture());
     MutableGraph generatedGraph = graphArgumentCaptor.getValue();
-    Graphviz.useEngine(new GraphvizV8Engine());
+    Graphviz.useDefaultEngines();
     String jsonGraph = Graphviz.fromGraph(generatedGraph).render(Format.JSON).toString();
     String ref = new String(Files
         .readAllBytes(Paths.get("src/test/resources/kafka-flows-mulefd-components-example.json")));


### PR DESCRIPTION
Use the default available Graphviz engines to avoid failures due to specific engine not being available. 

Fixes #244 by letting to use other available engines on Apple M1. See new Troubleshooting sections added to Readme with this PR.