### PR TITLE
fix: rollback the github checkout actions

### DIFF
--- a/.github/workflows/tag-and-release.yml
+++ b/.github/workflows/tag-and-release.yml
@@ -21,14 +21,17 @@ jobs:
       JRELEASER_GPG_SECRET_KEY: ${{ secrets.JRELEASER_GPG_SECRET_KEY }}
       JRELEASER_VERSION: 1.2.0
     steps:
-      - uses: actions/checkout@v2.4.2
+      - uses: actions/checkout@v1
       - name: Set up JDK 1.8
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@v1
         with:
-          java-version: 8
-          distribution: 'temurin'
-          check-latest: true
-          cache: 'gradle'
+          java-version: 1.8
+      - uses: actions/cache@v2.1.1
+        with:
+          path: ~/.gradle/caches
+          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle') }}
+          restore-keys: |
+            ${{ runner.os }}-gradle
       - name: build-gradle
         run: ./gradlew clean build install --build-cache --scan -s --no-daemon
       - name: integration-test


### PR DESCRIPTION
Checkout Actions@V2 broke the versioner plugin. It kept calculating initial versions. Rolling back to previously worked release worlflow version.