### PR TITLE
feat: support mule core components 

### DIFF
--- a/src/main/java/com/javastreets/mulefd/MuleXmlElement.java
+++ b/src/main/java/com/javastreets/mulefd/MuleXmlElement.java
@@ -60,6 +60,10 @@ public class MuleXmlElement {
     return ELEMENT_ERROR_HANDLER.equalsIgnoreCase(element.getNodeName());
   }
 
+  public static boolean isMuleCoreElement(Element element) {
+    return "mule".equalsIgnoreCase(element.getNodeName());
+  }
+
   public static boolean isFlowRef(MuleComponent component) {
     return component.getType().equalsIgnoreCase(ELEMENT_FLOW_REF);
   }
@@ -91,7 +95,6 @@ public class MuleXmlElement {
         if (isanErrorHandler(element)) {
           muleComponentList.addAll(parseContainerElement(element, knownComponents));
         }
-
         processKnownComponents(knownComponents, muleComponentList, element);
 
       }
@@ -115,6 +118,8 @@ public class MuleXmlElement {
     String[] wildcards = null;
     if (knownComponents.containsKey(keyName)) {
       item = knownComponents.get(keyName);
+    } else if (!element.getNodeName().contains(":")) {
+      item = knownComponents.get(MuleComponent.toMuleCoreComponentName(element.getNodeName()));
     } else if (element.getTagName().contains(":")) {
       wildcards = element.getTagName().split(":");
       String wildcardEntry = wildcards[0] + ":*";

--- a/src/main/java/com/javastreets/mulefd/model/MuleComponent.java
+++ b/src/main/java/com/javastreets/mulefd/model/MuleComponent.java
@@ -1,5 +1,8 @@
 package com.javastreets.mulefd.model;
 
+import java.util.Objects;
+
+
 public class MuleComponent extends Component {
   private boolean async;
   private boolean source;
@@ -28,6 +31,17 @@ public class MuleComponent extends Component {
 
   public void setSource(boolean source) {
     this.source = source;
+  }
+
+  /**
+   * Prefixes the provided name with mule namespace.
+   * 
+   * @param name {@link String} of a component
+   * @return String mule prefixed name
+   */
+  public static String toMuleCoreComponentName(String name) {
+    Objects.requireNonNull(name, "Component name cannot be null");
+    return "mule:" + name;
   }
 
   public Attribute<String, String> getConfigRef() {

--- a/src/main/resources/default-mule-components.csv
+++ b/src/main/resources/default-mule-components.csv
@@ -1,4 +1,5 @@
 prefix,operation,sourceFlag,path,configName,async
+mule,scheduler,true,,,false
 http,listener,true,path,config-ref,true
 http,request,false,path,config-ref,false
 apikit,*,false,api,config-ref,false

--- a/src/test/java/com/javastreets/mulefd/DiagramRendererTest.java
+++ b/src/test/java/com/javastreets/mulefd/DiagramRendererTest.java
@@ -36,7 +36,8 @@ class DiagramRendererTest {
   @Test
   @DisplayName("Empty source directory rendering return false")
   void emptySourceDirRendering() {
-    DiagramRenderer renderer = Mockito.spy(new DiagramRenderer(getCommandModel(tempDir.toPath())));
+    DiagramRenderer renderer =
+        Mockito.spy(new DiagramRenderer(getCommandModel(tempDir.toPath(), tempDir)));
     doReturn(Collections.emptyMap()).when(renderer).prepareKnownComponents();
     doReturn(false).when(renderer).diagram(any(DrawingContext.class));
     assertThat(renderer.render()).isFalse();
@@ -51,7 +52,8 @@ class DiagramRendererTest {
   @DisplayName("Skips rendering non-mule file")
   void skipsNonMuleFileRendering() {
     Path sourcePath = Paths.get("src/test/resources/renderer/non-mule");
-    DiagramRenderer renderer = Mockito.spy(new DiagramRenderer(getCommandModel(sourcePath)));
+    DiagramRenderer renderer =
+        Mockito.spy(new DiagramRenderer(getCommandModel(sourcePath, tempDir)));
     doReturn(Collections.emptyMap()).when(renderer).prepareKnownComponents();
     doReturn(false).when(renderer).diagram(any(DrawingContext.class));
     assertThat(renderer.render()).isFalse();
@@ -66,8 +68,8 @@ class DiagramRendererTest {
   @Test
   @DisplayName("Source directory rendering with one config")
   void singleFileRendering() {
-    DiagramRenderer renderer = Mockito
-        .spy(new DiagramRenderer(getCommandModel(Paths.get("src/test/resources/renderer/single"))));
+    DiagramRenderer renderer = Mockito.spy(new DiagramRenderer(
+        getCommandModel(Paths.get("src/test/resources/renderer/single"), tempDir)));
     doReturn(Collections.emptyMap()).when(renderer).prepareKnownComponents();
     doReturn(false).when(renderer).diagram(any(DrawingContext.class));
     assertThat(renderer.render()).isFalse();
@@ -82,7 +84,7 @@ class DiagramRendererTest {
   @Test
   @DisplayName("Create drawing context from command model")
   void toDrawingContext() {
-    CommandModel commandModel = getCommandModel(tempDir.toPath());
+    CommandModel commandModel = getCommandModel(tempDir.toPath(), tempDir);
     commandModel.setFlowName("test-flow");
     assertThat(new DiagramRenderer(commandModel).drawingContext(commandModel))
         .extracting(DrawingContext::getDiagramType, DrawingContext::getOutputFile,
@@ -95,7 +97,7 @@ class DiagramRendererTest {
   @Test
   @DisplayName("Create drawing context from command model with single generation as true")
   void toDrawingContextForSingles() {
-    CommandModel commandModel = getCommandModel(tempDir.toPath());
+    CommandModel commandModel = getCommandModel(tempDir.toPath(), tempDir);
     commandModel.setFlowName("test-flow");
     commandModel.setGenerateSingles(true);
     assertThat(new DiagramRenderer(commandModel).drawingContext(commandModel))
@@ -109,8 +111,9 @@ class DiagramRendererTest {
   @Test
   @DisplayName("Prepare components from csv file")
   void prepareKnownComponents() {
-    assertThat(new DiagramRenderer(getCommandModel(tempDir.toPath())).prepareKnownComponents())
-        .isNotEmpty();
+    assertThat(
+        new DiagramRenderer(getCommandModel(tempDir.toPath(), tempDir)).prepareKnownComponents())
+            .isNotEmpty();
   }
 
   @Test
@@ -118,8 +121,9 @@ class DiagramRendererTest {
   void prepareKnownComponentsWithMulefdFile() throws IOException {
     Files.copy(Paths.get("src/test/resources/mulefd-components.csv"),
         tempDir.toPath().resolve("mulefd-components.csv"), StandardCopyOption.REPLACE_EXISTING);
-    assertThat(new DiagramRenderer(getCommandModel(tempDir.toPath())).prepareKnownComponents())
-        .isNotEmpty().containsKey("kafka:message-listener");
+    assertThat(
+        new DiagramRenderer(getCommandModel(tempDir.toPath(), tempDir)).prepareKnownComponents())
+            .isNotEmpty().containsKey("kafka:message-listener");
     Files.deleteIfExists(Paths.get("./mulefd-components.csv"));
   }
 
@@ -127,7 +131,7 @@ class DiagramRendererTest {
   @DisplayName("Single config file as source")
   void sourcePathXmlFile() {
     Path sourcePath = Paths.get("src/test/resources/renderer/single/example-config.xml");
-    assertThat(new DiagramRenderer(getCommandModel(sourcePath)).getMuleSourcePath())
+    assertThat(new DiagramRenderer(getCommandModel(sourcePath, tempDir)).getMuleSourcePath())
         .as("Resolved mule configuration path").isEqualTo(sourcePath);
     logs.assertContains("Reading source file " + sourcePath.toString());
   }
@@ -136,7 +140,7 @@ class DiagramRendererTest {
   @DisplayName("Mule 4 source directory")
   void sourcePathMule4Directory() {
     Path sourcePath = Paths.get("src/test/resources/renderer/mule4-example");
-    assertThat(new DiagramRenderer(getCommandModel(sourcePath)).getMuleSourcePath())
+    assertThat(new DiagramRenderer(getCommandModel(sourcePath, tempDir)).getMuleSourcePath())
         .as("Resolved mule configuration path")
         .isEqualTo(Paths.get(sourcePath.toString(), "src/main/mule"));
     logs.assertContains(
@@ -147,7 +151,7 @@ class DiagramRendererTest {
   @DisplayName("Mule 3 - non-maven source directory")
   void sourcePathMule3NonMavenDirectory() {
     Path sourcePath = Paths.get("src/test/resources/renderer/mule3-example");
-    assertThat(new DiagramRenderer(getCommandModel(sourcePath)).getMuleSourcePath())
+    assertThat(new DiagramRenderer(getCommandModel(sourcePath, tempDir)).getMuleSourcePath())
         .as("Resolved mule configuration path")
         .isEqualTo(Paths.get(sourcePath.toString(), "src/main/app"));
     logs.assertContains(
@@ -158,7 +162,7 @@ class DiagramRendererTest {
   @DisplayName("Mule 3 - maven source directory")
   void sourcePathMule3MavenDirectory() {
     Path sourcePath = Paths.get("src/test/resources/renderer/mule3-maven-example");
-    assertThat(new DiagramRenderer(getCommandModel(sourcePath)).getMuleSourcePath())
+    assertThat(new DiagramRenderer(getCommandModel(sourcePath, tempDir)).getMuleSourcePath())
         .as("Resolved mule configuration path")
         .isEqualTo(Paths.get(sourcePath.toString(), "src/main/app"));
     logs.assertContains(

--- a/src/test/java/com/javastreets/mulefd/DiagramRendererTestUtil.java
+++ b/src/test/java/com/javastreets/mulefd/DiagramRendererTestUtil.java
@@ -1,5 +1,6 @@
 package com.javastreets.mulefd;
 
+import java.io.File;
 import java.io.IOException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -14,11 +15,16 @@ import com.javastreets.mulefd.model.FlowContainer;
 public class DiagramRendererTestUtil {
 
 
-  public static CommandModel getCommandModel(Path sourcePath) {
+  public static CommandModel getCommandModel(Path sourcePath, File tempDir) {
     CommandModel model = new CommandModel();
     model.setDiagramType(DiagramType.GRAPH);
+    if (tempDir != null) {
+      model.setTargetPath(tempDir.toPath());
+    } else {
+      model.setTargetPath(Paths.get("dummy-result-path"));
+    }
     model.setOutputFilename("test-output-file");
-    model.setTargetPath(Paths.get("dummy-result-path"));
+
     model.setSourcePath(sourcePath);
 
     return model;
@@ -26,13 +32,13 @@ public class DiagramRendererTestUtil {
 
 
   public static List<FlowContainer> getFlows(Path sourcePath) throws IOException {
-    CommandModel commandModel = getCommandModel(sourcePath);
+    CommandModel commandModel = getCommandModel(sourcePath, null);
     DiagramRenderer diagramRenderer = new DiagramRenderer(commandModel);
     return diagramRenderer.findFlows(diagramRenderer.drawingContext(commandModel));
   }
 
-  public static DrawingContext getDrawingContext(Path sourcePath) throws IOException {
-    CommandModel commandModel = getCommandModel(sourcePath);
+  public static DrawingContext getDrawingContext(Path sourcePath, File tempDir) throws IOException {
+    CommandModel commandModel = getCommandModel(sourcePath, tempDir);
     DiagramRenderer diagramRenderer = new DiagramRenderer(commandModel);
     DrawingContext context = diagramRenderer.drawingContext(commandModel);
     List<FlowContainer> flows = diagramRenderer.findFlows(context);

--- a/src/test/java/com/javastreets/mulefd/cli/DiagramBaseCommandTest.java
+++ b/src/test/java/com/javastreets/mulefd/cli/DiagramBaseCommandTest.java
@@ -43,8 +43,7 @@ class DiagramBaseCommandTest {
   @DisplayName("When parsing source file without parent folder, sets parent as target")
   void commandLineWithBareSourceFile() throws Exception {
     tempDir.createNewFile();
-    Path sourceFile = Paths.get("db-config.xml");
-    sourceFile.toFile().delete();
+    Path sourceFile = tempDir.toPath().resolve("db-config.xml");
     Files.copy(Paths.get("src/test/resources/renderer/component-configs/db-config.xml"),
         sourceFile);
     String[] args = new String[] {sourceFile.toString()};

--- a/src/test/java/com/javastreets/mulefd/drawings/GraphDiagramTest.java
+++ b/src/test/java/com/javastreets/mulefd/drawings/GraphDiagramTest.java
@@ -185,8 +185,6 @@ class GraphDiagramTest {
     ArgumentCaptor<MutableGraph> graphArgumentCaptor = ArgumentCaptor.forClass(MutableGraph.class);
     verify(graphDiagram).writGraphToFile(any(File.class), graphArgumentCaptor.capture());
     MutableGraph generatedGraph = graphArgumentCaptor.getValue();
-    GraphvizEngineHelper.generate(generatedGraph, Format.DOT,
-        Paths.get("test-output2.dot").toFile());
     String generated = GraphvizEngineHelper.generate(generatedGraph, Format.DOT);
     String ref = new String(Files.readAllBytes(Paths.get(
         "src/test/java/com/javastreets/mulefd/drawings/drawToValidateGraph_APIKIT_Expected.dot")));
@@ -394,6 +392,36 @@ class GraphDiagramTest {
     assertThat(written).isFalse();
   }
 
+  @Test
+  @DisplayName("Mule Core component flows - Scheduler")
+  void github_issue_301() throws Exception {
+
+    List flows =
+        DiagramRendererTestUtil.getFlows(Paths.get("src/test/resources/gh-issues/iss-301.xml"));
+    File output = new File(tempDir, "output.png");
+    DrawingContext context = new DrawingContext();
+    context.setDiagramType(DiagramType.GRAPH);
+    context.setOutputFile(output);
+    context.setComponents(flows);
+
+    ComponentItem item = new ComponentItem();
+    item.setPrefix("mule");
+    item.setOperation("scheduler");
+    item.setSource(true);
+    context.setKnownComponents(Collections.singletonMap(item.qualifiedName(), item));
+
+    GraphDiagram graphDiagram = Mockito.spy(new GraphDiagram());
+    when(graphDiagram.getDiagramHeaderLines()).thenReturn(new String[] {"Test Diagram"});
+    graphDiagram.draw(context);
+    ArgumentCaptor<MutableGraph> graphArgumentCaptor = ArgumentCaptor.forClass(MutableGraph.class);
+    verify(graphDiagram).writGraphToFile(any(File.class), graphArgumentCaptor.capture());
+    MutableGraph generatedGraph = graphArgumentCaptor.getValue();
+    String generated = GraphvizEngineHelper.generate(generatedGraph, Format.DOT);
+    Path path = Paths.get("src/test/resources/gh-issues/iss-301.dot");
+    GraphvizEngineHelper.generate(generatedGraph, Format.DOT);
+    String ref = new String(Files.readAllBytes(path));
+    assertThat(generated).as("DOT Graph").isEqualToNormalizingNewlines(ref);
+  }
 
   @Test
   @DisplayName("Distinguish same connector with different path")
@@ -401,7 +429,7 @@ class GraphDiagramTest {
 
     List flows =
         DiagramRendererTestUtil.getFlows(Paths.get("src/test/resources/gh-issues/iss-302.xml"));
-    File output = new File(".", "output.png");
+    File output = new File(tempDir, "output.png");
     DrawingContext context = new DrawingContext();
     context.setDiagramType(DiagramType.GRAPH);
     context.setOutputFile(output);
@@ -426,6 +454,4 @@ class GraphDiagramTest {
         new String(Files.readAllBytes(Paths.get("src/test/resources/gh-issues/iss-302.dot")));
     assertThat(generated).as("DOT Graph").isEqualToNormalizingNewlines(ref);
   }
-
-
 }

--- a/src/test/java/com/javastreets/mulefd/drawings/GraphDiagramTest.java
+++ b/src/test/java/com/javastreets/mulefd/drawings/GraphDiagramTest.java
@@ -89,7 +89,7 @@ class GraphDiagramTest {
   @DisplayName("Validate generated graph when generated as DOT.")
   void drawToValidateGraph() throws Exception {
 
-    File output = new File(".", "output.png");
+    File output = new File(tempDir, "output.png");
     DrawingContext context = new DrawingContext();
     context.setDiagramType(DiagramType.GRAPH);
     context.setOutputFile(output);
@@ -134,7 +134,7 @@ class GraphDiagramTest {
 
     List flows =
         DiagramRendererTestUtil.getFlows(Paths.get("src/test/resources/gh-issues/iss-256.xml"));
-    File output = new File(".", "output.png");
+    File output = new File(tempDir, "output.png");
     DrawingContext context = new DrawingContext();
     context.setDiagramType(DiagramType.GRAPH);
     context.setOutputFile(output);
@@ -165,7 +165,7 @@ class GraphDiagramTest {
   void drawToValidateGraph_APIKIT() throws Exception {
 
     List flows = DiagramRendererTestUtil.getFlows(Paths.get("src/test/resources/test-api.xml"));
-    File output = new File(".", "output.png");
+    File output = new File(tempDir, "output.png");
     DrawingContext context = new DrawingContext();
     context.setDiagramType(DiagramType.GRAPH);
     context.setOutputFile(output);
@@ -197,7 +197,7 @@ class GraphDiagramTest {
 
     List flows = DiagramRendererTestUtil
         .getFlows(Paths.get("src/test/resources/single-flow-generation-example.xml"));
-    File output = new File(".", "output.png");
+    File output = new File(tempDir, "output.png");
     DrawingContext context = new DrawingContext();
     context.setDiagramType(DiagramType.GRAPH);
     context.setOutputFile(output);
@@ -225,7 +225,7 @@ class GraphDiagramTest {
         Paths.get("./mulefd-components.csv"), StandardCopyOption.REPLACE_EXISTING);
 
     DrawingContext context = DiagramRendererTestUtil.getDrawingContext(
-        Paths.get("src/test/resources/kafka-flows-mulefd-components-example.xml"));
+        Paths.get("src/test/resources/kafka-flows-mulefd-components-example.xml"), tempDir);
 
     GraphDiagram graphDiagram = Mockito.spy(new GraphDiagram());
     when(graphDiagram.getDiagramHeaderLines()).thenReturn(new String[] {"Test Diagram"});

--- a/src/test/java/com/javastreets/mulefd/model/MuleComponentTest.java
+++ b/src/test/java/com/javastreets/mulefd/model/MuleComponentTest.java
@@ -1,6 +1,7 @@
 package com.javastreets.mulefd.model;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.catchThrowableOfType;
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -29,4 +30,16 @@ class MuleComponentTest {
 
   }
 
+  @Test
+  void toMuleCoreComponentName_withValidName() {
+    assertThat(MuleComponent.toMuleCoreComponentName("test")).isEqualTo("mule:test");
+  }
+
+  @SuppressWarnings("ResultOfMethodCallIgnored")
+  @Test
+  void toMuleCoreComponentName_withNullName() {
+    NullPointerException npe = catchThrowableOfType(
+        () -> MuleComponent.toMuleCoreComponentName(null), NullPointerException.class);
+    assertThat(npe).isNotNull().hasMessage("Component name cannot be null");
+  }
 }

--- a/src/test/resources/gh-issues/iss-301.dot
+++ b/src/test/resources/gh-issues/iss-301.dot
@@ -1,0 +1,41 @@
+digraph "mule" {
+edge ["dir"="forward"]
+graph ["rankdir"="LR","splines"="spline","pad"="1.0,0.5","dpi"="150","label"=<Test Diagram<br/>>,"labelloc"="t"]
+edge ["arrowhead"="vee","dir"="forward"]
+subgraph "cluster_legend" {
+edge ["dir"="forward"]
+graph ["label"=<<b>Legend</b>>,"style"="dashed"]
+"flow" ["fixedsize"="true","width"="1.0","height"="0.25","shape"="rectangle","color"="blue"]
+"sub-flow" ["fixedsize"="true","width"="1.0","height"="0.25","color"="black","shape"="ellipse"]
+"connector:operation" ["shape"="component"]
+"Unused sub/-flow" ["fixedsize"="true","width"="2.0","height"="0.25","color"="gray","style"="filled"]
+"Flow A" ["fixedsize"="true","width"="1.0","height"="0.25"]
+"sub-flow-1" ["fixedsize"="true","width"="1.25","height"="0.25"]
+"Flow C" ["fixedsize"="true","width"="1.0","height"="0.25"]
+"sub-flow-C1" ["fixedsize"="true","width"="1.25","height"="0.25"]
+"flow source" ["fixedsize"="true","width"="1.5","height"="0.25","shape"="hexagon","style"="filled","color"="cyan","sourceNode"="true"]
+"flow self-call" ["fixedsize"="true","width"="1.25","height"="0.25","shape"="rectangle","color"="blue"]
+"sub-flow self-call" ["fixedsize"="true","width"="2.0","height"="0.25","color"="black","shape"="ellipse"]
+"flow" -> "sub-flow" ["style"="invis"]
+"sub-flow" -> "Unused sub/-flow" ["style"="invis"]
+"Flow A" -> "sub-flow-1" ["style"="solid","label"="(1)","taillabel"="Call Sequence\n","labelangle"="-5.0","labeldistance"="8.0"]
+"Flow C" -> "sub-flow-C1" ["style"="dashed,bold","xlabel"="(1) Async","color"="lightblue3","taillabel"="Asynchronous call\n","labelangle"="-5.0","labeldistance"="8.0"]
+"flow source" -> "flow self-call" ["style"="invis"]
+"flow self-call" -> "flow self-call"
+"flow self-call" -> "sub-flow self-call" ["style"="invis"]
+"sub-flow self-call" -> "sub-flow self-call"
+}
+subgraph "cluster_legend-space" {
+edge ["dir"="none"]
+graph ["label"="","style"="invis"]
+"" ["shape"="none","width"="2.0","height"="1.0"]
+}
+subgraph "cluster_mule" {
+edge ["dir"="forward"]
+graph ["rankdir"="LR","splines"="spline","pad"="1.0,0.5","dpi"="150","label"=<Application graph<br/>>,"labelloc"="t","style"="invis"]
+edge ["arrowhead"="vee","dir"="forward"]
+"mule:scheduler" ["shape"="hexagon","style"="filled","color"="cyan","sourceNode"="true","label"=<<b>mule: scheduler</b><br/><br/>>]
+"flow:scheduler-configFlow" ["label"=<<b>flow</b>: scheduler-configFlow>,"shape"="rectangle","color"="blue"]
+"mule:scheduler" -> "flow:scheduler-configFlow" ["style"="bold"]
+}
+}

--- a/src/test/resources/gh-issues/iss-301.xml
+++ b/src/test/resources/gh-issues/iss-301.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<mule xmlns="http://www.mulesoft.org/schema/mule/core" xmlns:doc="http://www.mulesoft.org/schema/mule/documentation"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://www.mulesoft.org/schema/mule/core http://www.mulesoft.org/schema/mule/core/current/mule.xsd">
+	<flow name="scheduler-configFlow" doc:id="3a8687e8-ee8d-42fd-b3a0-d1740b1da621" >
+		<scheduler doc:name="Scheduler" doc:id="8a2088ba-a947-438c-97e5-b124f4386b18" >
+			<scheduling-strategy >
+				<cron expression="${cron.expreesion}" />
+			</scheduling-strategy>
+		</scheduler>
+		<logger level="INFO" doc:name="Logger" doc:id="2062d553-4a9a-4c40-b3a1-01ca6c6b305f" />
+	</flow>
+</mule>


### PR DESCRIPTION

- feat: Allow configuring core components in known components csv file and identifying corresponding components. Fixes https://github.com/manikmagar/mulefd/issues/301 by rendering schedulers from mule core components.
- test: clean up test file generation